### PR TITLE
Cambio de extensiones de imagen png-PNG programacion logica teoria

### DIFF
--- a/proglogica/logica_teoria/.ipynb_checkpoints/Programacion-logica-checkpoint.ipynb
+++ b/proglogica/logica_teoria/.ipynb_checkpoints/Programacion-logica-checkpoint.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "Dentro de los paradigmas de programación existen 2 grandes gurpos: que son los <strong>Declarativos</strong> y los <strong>Imperativos</strong>. Las características principales de ellos se ven en el siguiente gráfico.\n",
     "\n",
-    "<img src=\"imagenes/impdec.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/impdec.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "<p>\n",
     "Los desarrolladores web, pasan sus días dando instrucciones a las computadoras. Estas instrucciones generalmente implican algo de entrada (ej. una solicitud de una página web), algo de lógica (ej. obtener el contenido correcto de una base de datos) y algo de salida (ej. enviar el contenido al navegador solicitante). Este proceso de decir a un ordenador <b>cómo</b> realizar una tarea, es lo que comúnmente llamamos \"programación\", pero es sólo un subconjunto de programación: la programación <b>imperativa</b>.\n",
@@ -78,7 +78,7 @@
     "<p>\n",
     "Los lenguajes declarativos tienden a desvanecerse en el fondo de la programación, en parte porque están más cerca de cómo interactuamos naturalmente con la gente. Si estás hablando con un amigo y quieres un sándwich, normalmente no le das a tu amigo instrucciones paso a paso sobre cómo preparar el sándwich. Si lo hiciera, se sentiría como la programación de su amigo. En cambio, es mucho más probable que hable sobre el resultado que desea, como <i>\"Por favor, hazme un sandwich\"</i> (o, tal vez, <i>\"Sudo hazme un sandwich\"</i>). Si su amigo está dispuesto y es capaz de seguir esta instrucción, entonces traducirán la frase <i>\"Hazme un sandwich\"</i> en una serie de pasos, como encontrar un pan, quitar dos rebanadas, aplicar coberturas, etc.\n",
     "</p>\n",
-    "<img src=\"imagenes/impdec002.png\" style=\"max-width:100%; width: 30%; max-width: none\">"
+    "<img src=\"imagenes/impdec002.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">"
    ]
   },
   {
@@ -99,7 +99,7 @@
     "<p>\n",
     "En la mitad del siglo XX descubrimos que de forma paralela al desarrollo de la lógica se ha producido un espectacular avance de las llamadas “máquinas de calcular”, avance sobre el que reflexiona Alan Turing en un articulo titulado <i>“¿Pueden pensar las máquinas?”</i>, publicado en 1950 y que podemos dar como punto de partida de lo que después se llamará Inteligencia Artificial.\n",
     "</p>\n",
-    "<img src=\"imagenes/historia.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/historia.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "<p>\n",
     "El primer momento en el que se usa la lógica matemática para representar y ejecutar programas es en <b>1930</b> cuando aparece como una caracteristica de los <i>cálculos lamba</i> desarrollados por <b>Allonzo Church</b>.\n",
     "</p>\n",
@@ -180,7 +180,7 @@
     "\n",
     "También llamada <b><i>lógica de enunciados</i></b>: toma como elemento básico las frases declarativas simples o proposiciones. Su estructura está dada por:\n",
     "\n",
-    "<img src=\"imagenes/propo001.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/propo001.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "\n",
     "<p>\n",
     "Es un sistema formal cuyos elementos más simples representan proposiciones, y cuyas constantes lógicas, llamadas conectivas lógicas, representan operaciones sobre proposiciones, capaces de formar otras proposiciones de mayor complejidad.\n",
@@ -195,7 +195,7 @@
     "\n",
     "<b>Proposición Compuesta:</b> <i>“Pepito es hombre y pepita es mujer”</i>.\n",
     "\n",
-    "<img src=\"imagenes/propo002.png\" style=\"max-width:100%; width: 80%; max-width: none\">"
+    "<img src=\"imagenes/propo002.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">"
    ]
   },
   {
@@ -206,7 +206,7 @@
     "\n",
     "También llamada <b><i>lógica de predicados</i></b>: es un sistema deductivo basado en un Lenguaje Lógico Matemático formal. Su estructura esta dada por:\n",
     "\n",
-    "<img src=\"imagenes/predi.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/predi.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Incluye proposiciones lógicas, predicados y cuantificadores.\n",
     "\n",
@@ -228,7 +228,7 @@
     "Secuencia de literales que contiene a lo sumo uno de sus literales positivos (disyunción de literales).\n",
     "Esto es un ejemplo de una cláusula de Horn, y abajo se indica una fórmula como esta también puede reescribirse de forma equivalente como una implicación:\n",
     "\n",
-    "<img src=\"imagenes/horn001.png\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
+    "<img src=\"imagenes/horn001.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li><b>Cláusula ‘definite’:</b> Cláusula de Horn con exactamente un literal positivo.</li>\n",
@@ -244,9 +244,9 @@
     "\n",
     "<b>Ej:</b>\n",
     "Estructura de clúasulas de Horn\n",
-    "<img src=\"imagenes/horn002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/horn002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "Estructura de clúasulas de Horn en Prolog\n",
-    "<img src=\"imagenes/horn003.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/horn003.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "<p>\n",
     "Los programas en Prolog se componen de <b>cláusulas de Horn</b> que constituyen reglas del tipo <i>\"modus ponendo ponens\"</i>, es decir, <b><i>\"Si es verdad el antecedente, entonces es verdad el consecuente\"</i></b>. No obstante, la forma de escribir las cláusulas de Horn es al contrario de lo habitual. <i>Primero se escribe el consecuente y luego el antecedente</i>. El antecedente puede ser una conjunción de condiciones que se denomina secuencia de objetivos. Cada objetivo se separa con una coma y puede considerarse similar a una instrucción o llamada a procedimiento de los lenguajes imperativos. En Prolog no existen instrucciones de control. Su ejecución se basa en dos conceptos: la <b>unificación</b> y el <b>backtracking</b>.\n",
     "</p>\n",
-    "<img src=\"imagenes/tree001.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree001.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "<p>\n",
     "Gracias a la <b>unificación</b>, cada objetivo determina un <b>subconjunto de cláusulas susceptibles de ser ejecutadas</b>. Cada una de ellas se denomina <b>punto de elección</b>. Prolog selecciona el <b>primer punto de elección</b> y sigue ejecutando el programa hasta determinar si el objetivo es <font color=\"green\">verdadero</font> o <font color=\"red\">falso</font>.\n",
     "</p>\n",
@@ -292,17 +292,17 @@
     "A continuación veremos un ejemplo de backtracking en caso de que todos los objetivos son <font color=\"red\">falsos</font>.\n",
     "</p>\n",
     "\n",
-    "<img src=\"imagenes/tree002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree003.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree003.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Selecciona el primer punto de elección.\n",
     "\n",
-    "<img src=\"imagenes/tree004.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree005.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree004.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree005.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Si encuentra un objetivo <font color=\"red\">falso</font> realiza <b>backtracking</b> hasta el punto de elección anterior, y continua.\n",
     "\n",
-    "<img src=\"imagenes/tree006.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree006.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Repite el mismo procedimiento y en caso de no encontrar objetivo <font color=\"red\">verdadero</font>, y no tener más puntos de elección que recorrer devuelve <font color=\"red\">falso</font> como resultado de la consulta.\n",
     "\n",
@@ -310,9 +310,9 @@
     "\n",
     "En caso de que todos alguno de los objetivos sea <font color=\"green\">verdadero</font> este es el recorrido.\n",
     "\n",
-    "<img src=\"imagenes/tree008.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree009.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree010.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n"
+    "<img src=\"imagenes/tree008.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree009.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree010.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n"
    ]
   },
   {
@@ -332,7 +332,7 @@
     "\n",
     "Son las sentencias más sencillas. Un hecho es una fórmula atómica o átomo: $p(t_{1}, ..., t_{n})$ e indica que se verifica la relación (predicado) <b>p</b> sobre los objetos (términos) $t_{1}, ..., t_{n}$. \n",
     "\n",
-    "<img src=\"imagenes/hecho.png\" style=\"max-width:100%; width: 30%; max-width: none\">"
+    "<img src=\"imagenes/hecho.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">"
    ]
   },
   {
@@ -343,7 +343,7 @@
     "\n",
     "Implicación o inferencia lógica que deduce nuevo conocimiento, la regla permite definir nuevas relaciones apartir de otras ya existentes\n",
     "\n",
-    "<img src=\"imagenes/regla.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/regla.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -354,7 +354,7 @@
     "\n",
     "se especifica el problema, la proposición a demostrar o el objetivo Partiendo de que los humanos son mortales y de que Sócrates es humano, deducimos que <i> Pepito es mortal</i>\n",
     "\n",
-    "<img src=\"imagenes/consulta.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/consulta.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "\n",
     "En un ámbito más matemático ésta idea puede ser utilizada para resolver operaciones sencillas como es el caso de las sumatorias o factoriales, en general cualquier operación que requiera información del resultado que generan valores inferiores al dado. Un ejemplo de ésto podría ser el hallar las potencias de dos dado el exponente en la función, lo cual puede ser hallado con el siguiente programa de prolog.\n",
     "\n",
-    "<img src=\"imagenes/recurs.png\" style=\"max-width:100%; width: 25%; max-width: none\">"
+    "<img src=\"imagenes/recurs.PNG\" style=\"max-width:100%; width: 25%; max-width: none\">"
    ]
   },
   {
@@ -384,8 +384,8 @@
    "source": [
     "### Ejemplo:\n",
     "Un conjunto de hechos constituye un programa (la forma más simple de programa lógico) que puede ser visto como una base de datos que describe una situación. Por ejemplo, el Programa 1 refleja la base de datos de las relaciones familiares que se muestran en el siguiente gráfico.\n",
-    "<img src=\"imagenes/ej0011.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/ej002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/ej0011.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/ej002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "<p>\n",
     "Todos los hechos de este programa son hechos de base (sin variables), pero también se pueden introducir hechos con variables como axiomas,por ejemplo: $suma(0, X, X)$. En ellos, las variables se consideran cuantificadas universalmente. Es decir, \t&#8704;$x$ $suma(0, x, x)$.\n",
     "</p>\n",
@@ -396,7 +396,7 @@
     "Una vez que se tiene el programa describiendo una situación, se pueden hacer consultas para obtener información acerca de él. Por ejemplo, podemos hacer consultas al Programa 1 del tipo siguiente:\n",
     "</p>\n",
     "\n",
-    "<img src=\"imagenes/ej003.png\" style=\"max-width:100%; width: 40%; max-width: none\">"
+    "<img src=\"imagenes/ej003.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "\n",
     "<p>Escribir un programa en Prolog consiste en declarar el conocimiento disponible acerca de objetos, además de sus relaciones y sus reglas, en lugar de correr un programa para obtener una solución, se hace una pregunta, el programa revisa la base de datos para encontrar la solución a la pregunta, si existe mas de una solución, Prolog hace un barrido para encontrar soluciones distintas. El propio sistema es el que deduce las respuestas a las preguntas que se le plantean, dichas respuestas las deduce del conocimiento obtenido por el conjunto de reglas dadas.</p>\n",
     "\n",
-    "<img src=\"imagenes/prologhw.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/prologhw.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li>Alain Colmerauer y Philippe Roussel (Finales de los 70’s)</li>\n",
@@ -484,17 +484,17 @@
     "<li>La comunicación con el programa es mediante una librería de funciones que necesitan como parámetro el estado anterior del “mundo” además del resto de parámetros que considere el usuario necesario y dan como salida el nuevo estado del “mundo” además de otros resultados específicos.</li>\n",
     "<li>\n",
     "La declaración de tipos en Mercury se hace de manera lógica:\n",
-    "<img src=\"imagenes/mer001.png\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
+    "<img src=\"imagenes/mer001.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
     "</li>\n",
     "<li>\n",
     "Se puede predeterminar el número de veces que se va a llamar a un predicado dentro del programa.\n",
-    "<img src=\"imagenes/mer002.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/mer002.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "“det” indica una vez, “semidet” como mucho una vez, “multi” al menos una vez y “nondet” un número arbitrario de veces El compilador comprobará que se cumple y, en caso contrario, rechazará el programa.\n",
     "</li>\n",
     "<li>Mercury tiene un sistema modular. Los programas consisten en la composición de uno o más módulos. Cada módulo tiene una sección llamada <i>interface</i> donde se declaran todos los tipos, funciones y predicados que se pueden exportar a otros módulos y otra sección <i>mplementation</i> donde están las definiciones de las entidades exportadas así como definiciones de tipos y predicados no exportables, locales al módulo.</li>\n",
     "<li>El compilador genera código muy eficiente</li>\n",
     "\n",
-    "<img src=\"imagenes/mer003.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/mer003.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li>Fergus Henderson, Thomas Conway y Zoltan Somogyi (1995)</li>\n",
@@ -509,7 +509,7 @@
     "Otra extensión de Prolog, especializado en los problemas <b>CSPs (Constraint Satisfaction Problem)</b>. De forma general, podemos decir que un programa en CLP(FD) consta de tres partes: “generación de variables” (donde también se especifica su domino), “definición de restricciones” (sobre las variables) y “labeling”, donde se instancian las variables por enumeración. \n",
     "</p>\n",
     "<b>Ejemplo:</b> SEND MORE MONEY puzzle\n",
-    "<img src=\"imagenes/clp.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/clp.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "### Godel\n",
     "<p>\n",
@@ -520,14 +520,14 @@
     "Es un buen lenguaje para tareas de meta-programación, tales como compilación, depuración, análisis, verificación o transformación de programas, ya que es mucho más declarativo que Prolog, por ejemplo. Como curiosidad, se puede destacar que este lenguaje no funciona en un entorno Windows.\n",
     "</p>\n",
     "<b>Ejemplo:</b> Máximo Común Divisor \n",
-    "<img src=\"imagenes/godel.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/godel.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "### Otros Ejemplos:\n",
     "<ul>\n",
-    "<li> Grafos dirigidos en Prolog, busqueda de caminos <img src=\"imagenes/prolog001.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Serie fibonacci en Prolog <img src=\"imagenes/prolog002.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Serie fibonacci en Mercury <img src=\"imagenes/prolog003.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Juego de ahorcado en Prolog <img src=\"imagenes/prolog004.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Grafos dirigidos en Prolog, busqueda de caminos <img src=\"imagenes/prolog001.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Serie fibonacci en Prolog <img src=\"imagenes/prolog002.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Serie fibonacci en Mercury <img src=\"imagenes/prolog003.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Juego de ahorcado en Prolog <img src=\"imagenes/prolog004.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
     "</ul>"
    ]
   },
@@ -543,7 +543,7 @@
     "<li>Construcción de Sistemas expertos, donde un Sistema de información mita las recomendaciones de un experto sobre algún dominio de conocimiento.</li>\n",
     "<li>Procesamiento del lenguaje natural, donde un programa es capaz de comprender (con limitaciones) la información contenida en una expresión lingüística humana.</li>\n",
     "Acontinuación se presenta un ejemplo simple de procesamiento de lenguaje natural.\n",
-    "<img src=\"imagenes/prolog005.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/prolog005.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "<li>Consultas lógicas basadas en reglas\n",
     "    <ul>\n",
     "    <li>Búsquedas en bases de datos</li>\n",

--- a/proglogica/logica_teoria/Programacion-logica.ipynb
+++ b/proglogica/logica_teoria/Programacion-logica.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "Dentro de los paradigmas de programación existen 2 grandes gurpos: que son los <strong>Declarativos</strong> y los <strong>Imperativos</strong>. Las características principales de ellos se ven en el siguiente gráfico.\n",
     "\n",
-    "<img src=\"imagenes/impdec.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/impdec.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "<p>\n",
     "Los desarrolladores web, pasan sus días dando instrucciones a las computadoras. Estas instrucciones generalmente implican algo de entrada (ej. una solicitud de una página web), algo de lógica (ej. obtener el contenido correcto de una base de datos) y algo de salida (ej. enviar el contenido al navegador solicitante). Este proceso de decir a un ordenador <b>cómo</b> realizar una tarea, es lo que comúnmente llamamos \"programación\", pero es sólo un subconjunto de programación: la programación <b>imperativa</b>.\n",
@@ -78,7 +78,7 @@
     "<p>\n",
     "Los lenguajes declarativos tienden a desvanecerse en el fondo de la programación, en parte porque están más cerca de cómo interactuamos naturalmente con la gente. Si estás hablando con un amigo y quieres un sándwich, normalmente no le das a tu amigo instrucciones paso a paso sobre cómo preparar el sándwich. Si lo hiciera, se sentiría como la programación de su amigo. En cambio, es mucho más probable que hable sobre el resultado que desea, como <i>\"Por favor, hazme un sandwich\"</i> (o, tal vez, <i>\"Sudo hazme un sandwich\"</i>). Si su amigo está dispuesto y es capaz de seguir esta instrucción, entonces traducirán la frase <i>\"Hazme un sandwich\"</i> en una serie de pasos, como encontrar un pan, quitar dos rebanadas, aplicar coberturas, etc.\n",
     "</p>\n",
-    "<img src=\"imagenes/impdec002.png\" style=\"max-width:100%; width: 30%; max-width: none\">"
+    "<img src=\"imagenes/impdec002.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">"
    ]
   },
   {
@@ -99,7 +99,7 @@
     "<p>\n",
     "En la mitad del siglo XX descubrimos que de forma paralela al desarrollo de la lógica se ha producido un espectacular avance de las llamadas “máquinas de calcular”, avance sobre el que reflexiona Alan Turing en un articulo titulado <i>“¿Pueden pensar las máquinas?”</i>, publicado en 1950 y que podemos dar como punto de partida de lo que después se llamará Inteligencia Artificial.\n",
     "</p>\n",
-    "<img src=\"imagenes/historia.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/historia.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "<p>\n",
     "El primer momento en el que se usa la lógica matemática para representar y ejecutar programas es en <b>1930</b> cuando aparece como una caracteristica de los <i>cálculos lamba</i> desarrollados por <b>Allonzo Church</b>.\n",
     "</p>\n",
@@ -180,7 +180,7 @@
     "\n",
     "También llamada <b><i>lógica de enunciados</i></b>: toma como elemento básico las frases declarativas simples o proposiciones. Su estructura está dada por:\n",
     "\n",
-    "<img src=\"imagenes/propo001.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/propo001.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "\n",
     "<p>\n",
     "Es un sistema formal cuyos elementos más simples representan proposiciones, y cuyas constantes lógicas, llamadas conectivas lógicas, representan operaciones sobre proposiciones, capaces de formar otras proposiciones de mayor complejidad.\n",
@@ -195,7 +195,7 @@
     "\n",
     "<b>Proposición Compuesta:</b> <i>“Pepito es hombre y pepita es mujer”</i>.\n",
     "\n",
-    "<img src=\"imagenes/propo002.png\" style=\"max-width:100%; width: 80%; max-width: none\">"
+    "<img src=\"imagenes/propo002.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">"
    ]
   },
   {
@@ -206,7 +206,7 @@
     "\n",
     "También llamada <b><i>lógica de predicados</i></b>: es un sistema deductivo basado en un Lenguaje Lógico Matemático formal. Su estructura esta dada por:\n",
     "\n",
-    "<img src=\"imagenes/predi.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/predi.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Incluye proposiciones lógicas, predicados y cuantificadores.\n",
     "\n",
@@ -228,7 +228,7 @@
     "Secuencia de literales que contiene a lo sumo uno de sus literales positivos (disyunción de literales).\n",
     "Esto es un ejemplo de una cláusula de Horn, y abajo se indica una fórmula como esta también puede reescribirse de forma equivalente como una implicación:\n",
     "\n",
-    "<img src=\"imagenes/horn001.png\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
+    "<img src=\"imagenes/horn001.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li><b>Cláusula ‘definite’:</b> Cláusula de Horn con exactamente un literal positivo.</li>\n",
@@ -244,9 +244,9 @@
     "\n",
     "<b>Ej:</b>\n",
     "Estructura de clúasulas de Horn\n",
-    "<img src=\"imagenes/horn002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/horn002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "Estructura de clúasulas de Horn en Prolog\n",
-    "<img src=\"imagenes/horn003.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/horn003.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "<p>\n",
     "Los programas en Prolog se componen de <b>cláusulas de Horn</b> que constituyen reglas del tipo <i>\"modus ponendo ponens\"</i>, es decir, <b><i>\"Si es verdad el antecedente, entonces es verdad el consecuente\"</i></b>. No obstante, la forma de escribir las cláusulas de Horn es al contrario de lo habitual. <i>Primero se escribe el consecuente y luego el antecedente</i>. El antecedente puede ser una conjunción de condiciones que se denomina secuencia de objetivos. Cada objetivo se separa con una coma y puede considerarse similar a una instrucción o llamada a procedimiento de los lenguajes imperativos. En Prolog no existen instrucciones de control. Su ejecución se basa en dos conceptos: la <b>unificación</b> y el <b>backtracking</b>.\n",
     "</p>\n",
-    "<img src=\"imagenes/tree001.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree001.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "<p>\n",
     "Gracias a la <b>unificación</b>, cada objetivo determina un <b>subconjunto de cláusulas susceptibles de ser ejecutadas</b>. Cada una de ellas se denomina <b>punto de elección</b>. Prolog selecciona el <b>primer punto de elección</b> y sigue ejecutando el programa hasta determinar si el objetivo es <font color=\"green\">verdadero</font> o <font color=\"red\">falso</font>.\n",
     "</p>\n",
@@ -292,17 +292,17 @@
     "A continuación veremos un ejemplo de backtracking en caso de que todos los objetivos son <font color=\"red\">falsos</font>.\n",
     "</p>\n",
     "\n",
-    "<img src=\"imagenes/tree002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree003.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree003.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Selecciona el primer punto de elección.\n",
     "\n",
-    "<img src=\"imagenes/tree004.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree005.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree004.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree005.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Si encuentra un objetivo <font color=\"red\">falso</font> realiza <b>backtracking</b> hasta el punto de elección anterior, y continua.\n",
     "\n",
-    "<img src=\"imagenes/tree006.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree006.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "Repite el mismo procedimiento y en caso de no encontrar objetivo <font color=\"red\">verdadero</font>, y no tener más puntos de elección que recorrer devuelve <font color=\"red\">falso</font> como resultado de la consulta.\n",
     "\n",
@@ -310,9 +310,9 @@
     "\n",
     "En caso de que todos alguno de los objetivos sea <font color=\"green\">verdadero</font> este es el recorrido.\n",
     "\n",
-    "<img src=\"imagenes/tree008.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree009.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/tree010.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n"
+    "<img src=\"imagenes/tree008.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree009.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/tree010.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n"
    ]
   },
   {
@@ -332,7 +332,7 @@
     "\n",
     "Son las sentencias más sencillas. Un hecho es una fórmula atómica o átomo: $p(t_{1}, ..., t_{n})$ e indica que se verifica la relación (predicado) <b>p</b> sobre los objetos (términos) $t_{1}, ..., t_{n}$. \n",
     "\n",
-    "<img src=\"imagenes/hecho.png\" style=\"max-width:100%; width: 30%; max-width: none\">"
+    "<img src=\"imagenes/hecho.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">"
    ]
   },
   {
@@ -343,7 +343,7 @@
     "\n",
     "Implicación o inferencia lógica que deduce nuevo conocimiento, la regla permite definir nuevas relaciones apartir de otras ya existentes\n",
     "\n",
-    "<img src=\"imagenes/regla.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/regla.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -354,7 +354,7 @@
     "\n",
     "se especifica el problema, la proposición a demostrar o el objetivo Partiendo de que los humanos son mortales y de que Sócrates es humano, deducimos que <i> Pepito es mortal</i>\n",
     "\n",
-    "<img src=\"imagenes/consulta.png\" style=\"max-width:100%; width: 50%; max-width: none\">"
+    "<img src=\"imagenes/consulta.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">"
    ]
   },
   {
@@ -375,7 +375,7 @@
     "\n",
     "En un ámbito más matemático ésta idea puede ser utilizada para resolver operaciones sencillas como es el caso de las sumatorias o factoriales, en general cualquier operación que requiera información del resultado que generan valores inferiores al dado. Un ejemplo de ésto podría ser el hallar las potencias de dos dado el exponente en la función, lo cual puede ser hallado con el siguiente programa de prolog.\n",
     "\n",
-    "<img src=\"imagenes/recurs.png\" style=\"max-width:100%; width: 25%; max-width: none\">"
+    "<img src=\"imagenes/recurs.PNG\" style=\"max-width:100%; width: 25%; max-width: none\">"
    ]
   },
   {
@@ -384,8 +384,8 @@
    "source": [
     "### Ejemplo:\n",
     "Un conjunto de hechos constituye un programa (la forma más simple de programa lógico) que puede ser visto como una base de datos que describe una situación. Por ejemplo, el Programa 1 refleja la base de datos de las relaciones familiares que se muestran en el siguiente gráfico.\n",
-    "<img src=\"imagenes/ej0011.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
-    "<img src=\"imagenes/ej002.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/ej0011.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/ej002.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "<p>\n",
     "Todos los hechos de este programa son hechos de base (sin variables), pero también se pueden introducir hechos con variables como axiomas,por ejemplo: $suma(0, X, X)$. En ellos, las variables se consideran cuantificadas universalmente. Es decir, \t&#8704;$x$ $suma(0, x, x)$.\n",
     "</p>\n",
@@ -396,7 +396,7 @@
     "Una vez que se tiene el programa describiendo una situación, se pueden hacer consultas para obtener información acerca de él. Por ejemplo, podemos hacer consultas al Programa 1 del tipo siguiente:\n",
     "</p>\n",
     "\n",
-    "<img src=\"imagenes/ej003.png\" style=\"max-width:100%; width: 40%; max-width: none\">"
+    "<img src=\"imagenes/ej003.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "\n",
     "<p>Escribir un programa en Prolog consiste en declarar el conocimiento disponible acerca de objetos, además de sus relaciones y sus reglas, en lugar de correr un programa para obtener una solución, se hace una pregunta, el programa revisa la base de datos para encontrar la solución a la pregunta, si existe mas de una solución, Prolog hace un barrido para encontrar soluciones distintas. El propio sistema es el que deduce las respuestas a las preguntas que se le plantean, dichas respuestas las deduce del conocimiento obtenido por el conjunto de reglas dadas.</p>\n",
     "\n",
-    "<img src=\"imagenes/prologhw.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/prologhw.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li>Alain Colmerauer y Philippe Roussel (Finales de los 70’s)</li>\n",
@@ -484,17 +484,17 @@
     "<li>La comunicación con el programa es mediante una librería de funciones que necesitan como parámetro el estado anterior del “mundo” además del resto de parámetros que considere el usuario necesario y dan como salida el nuevo estado del “mundo” además de otros resultados específicos.</li>\n",
     "<li>\n",
     "La declaración de tipos en Mercury se hace de manera lógica:\n",
-    "<img src=\"imagenes/mer001.png\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
+    "<img src=\"imagenes/mer001.PNG\" style=\"max-width:100%; width: 30%; max-width: none\">\n",
     "</li>\n",
     "<li>\n",
     "Se puede predeterminar el número de veces que se va a llamar a un predicado dentro del programa.\n",
-    "<img src=\"imagenes/mer002.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/mer002.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "“det” indica una vez, “semidet” como mucho una vez, “multi” al menos una vez y “nondet” un número arbitrario de veces El compilador comprobará que se cumple y, en caso contrario, rechazará el programa.\n",
     "</li>\n",
     "<li>Mercury tiene un sistema modular. Los programas consisten en la composición de uno o más módulos. Cada módulo tiene una sección llamada <i>interface</i> donde se declaran todos los tipos, funciones y predicados que se pueden exportar a otros módulos y otra sección <i>mplementation</i> donde están las definiciones de las entidades exportadas así como definiciones de tipos y predicados no exportables, locales al módulo.</li>\n",
     "<li>El compilador genera código muy eficiente</li>\n",
     "\n",
-    "<img src=\"imagenes/mer003.png\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
+    "<img src=\"imagenes/mer003.PNG\" style=\"max-width:100%; width: 40%; max-width: none\">\n",
     "\n",
     "<ul>\n",
     "<li>Fergus Henderson, Thomas Conway y Zoltan Somogyi (1995)</li>\n",
@@ -509,7 +509,7 @@
     "Otra extensión de Prolog, especializado en los problemas <b>CSPs (Constraint Satisfaction Problem)</b>. De forma general, podemos decir que un programa en CLP(FD) consta de tres partes: “generación de variables” (donde también se especifica su domino), “definición de restricciones” (sobre las variables) y “labeling”, donde se instancian las variables por enumeración. \n",
     "</p>\n",
     "<b>Ejemplo:</b> SEND MORE MONEY puzzle\n",
-    "<img src=\"imagenes/clp.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/clp.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "### Godel\n",
     "<p>\n",
@@ -520,14 +520,14 @@
     "Es un buen lenguaje para tareas de meta-programación, tales como compilación, depuración, análisis, verificación o transformación de programas, ya que es mucho más declarativo que Prolog, por ejemplo. Como curiosidad, se puede destacar que este lenguaje no funciona en un entorno Windows.\n",
     "</p>\n",
     "<b>Ejemplo:</b> Máximo Común Divisor \n",
-    "<img src=\"imagenes/godel.png\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
+    "<img src=\"imagenes/godel.PNG\" style=\"max-width:100%; width: 50%; max-width: none\">\n",
     "\n",
     "### Otros Ejemplos:\n",
     "<ul>\n",
-    "<li> Grafos dirigidos en Prolog, busqueda de caminos <img src=\"imagenes/prolog001.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Serie fibonacci en Prolog <img src=\"imagenes/prolog002.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Serie fibonacci en Mercury <img src=\"imagenes/prolog003.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
-    "<li> Juego de ahorcado en Prolog <img src=\"imagenes/prolog004.png\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Grafos dirigidos en Prolog, busqueda de caminos <img src=\"imagenes/prolog001.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Serie fibonacci en Prolog <img src=\"imagenes/prolog002.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Serie fibonacci en Mercury <img src=\"imagenes/prolog003.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
+    "<li> Juego de ahorcado en Prolog <img src=\"imagenes/prolog004.PNG\" style=\"max-width:100%; width: 80%; max-width: none\"></li>\n",
     "</ul>"
    ]
   },
@@ -543,7 +543,7 @@
     "<li>Construcción de Sistemas expertos, donde un Sistema de información mita las recomendaciones de un experto sobre algún dominio de conocimiento.</li>\n",
     "<li>Procesamiento del lenguaje natural, donde un programa es capaz de comprender (con limitaciones) la información contenida en una expresión lingüística humana.</li>\n",
     "Acontinuación se presenta un ejemplo simple de procesamiento de lenguaje natural.\n",
-    "<img src=\"imagenes/prolog005.png\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
+    "<img src=\"imagenes/prolog005.PNG\" style=\"max-width:100%; width: 80%; max-width: none\">\n",
     "<li>Consultas lógicas basadas en reglas\n",
     "    <ul>\n",
     "    <li>Búsquedas en bases de datos</li>\n",


### PR DESCRIPTION
Integrantes:
aapiragautau - lemartinp

Se entrega el aporte a la página con los aspectos teóricos del paradigma de programación lógica, se agrega todo la información expuesta durante la clase incluyendo información adicional y algunos ejemplos en prolog mediante la herramienta http://swish.swi-prolog.org/.

Se agregó un enlace público al taller teórico y a la presentación.
Se quitaron todas las referencias al directorio "files" en las imágenes.

- Se cambio la extensión de las imágenes de png a PNG