### PR TITLE
POA Teoría 2026-1

### DIFF
--- a/poa/poa_teoria/Pages/aplicaciones.html
+++ b/poa/poa_teoria/Pages/aplicaciones.html
@@ -159,6 +159,58 @@
 			</p>		
 
         </li>
+
+			<b>Resilience4J</b>
+            <p align="justify">
+				Es la biblioteca estándar en el ecosistema Java para implementar patrones de resiliencia en
+				arquitecturas de microservicios, y el sucesor directo de Hystrix, la solución que Netflix
+				desarrolló para evitar fallos en cascada entre servicios. Sus anotaciones
+				<code>@CircuitBreaker</code>, <code>@Retry</code>, <code>@RateLimiter</code> y
+				<code>@Bulkhead</code> son aspectos de Spring AOP que envuelven los métodos anotados en el
+				patrón de resiliencia correspondiente. Un servicio que se comunica con una API externa puede
+				tener reintentos automáticos, apertura de circuito y limitación de tasa aplicados de forma
+				completamente transparente, sin que el código de la llamada contenga ninguna lógica de
+				resiliencia.
+			</p></br>
+
+			<b>Micronaut y Quarkus</b>
+            <p align="justify">
+				Nacidos en 2018 y 2019 respectivamente, ambos frameworks representan un enfoque moderno al
+				problema que GraalVM Native Image planteó para AOP: la compilación a binarios nativos es
+				incompatible con la generación dinámica de proxies que Spring AOP usa en runtime. La
+				solución de ambos fue resolver sus aspectos completamente en tiempo de compilación mediante
+				procesadores de anotaciones, minimizando o evitando la necesidad de reflexión y proxies
+				dinámicos en ejecución para las capacidades transversales principales. El resultado son
+				aplicaciones con tiempos de arranque medidos en milisegundos y plenas capacidades
+				transversales —caché, transacciones, seguridad— que han ganado adopción en contextos
+				cloud-native y serverless donde el tiempo de inicio es un requerimiento crítico.
+			</p></br>
+
+			<b>NestJS</b>
+            <p align="justify">
+				En el ecosistema TypeScript, NestJS es el framework de backend más utilizado para Node.js.
+				Sus <em>Interceptors</em> y <em>Guards</em> implementan directamente los conceptos de AOP
+				sin nombrarlo así: los Interceptors son equivalentes funcionales de los <em>around advice</em>,
+				capaces de ejecutar código antes y después de la respuesta de un controlador, transformar el
+				resultado o cortocircuitar la ejecución; los Guards actúan como <em>before advice</em> de
+				control de acceso. Ambos se definen como unidades independientes y se aplican
+				declarativamente mediante decoradores de TypeScript, lo que permite que preocupaciones
+				transversales como autenticación, logging y transformación de respuestas no aparezcan en
+				ningún controlador.
+			</p></br>
+
+			<b>Firebase Performance Monitoring</b>
+            <p align="justify">
+				El plugin de Gradle de Firebase Performance Monitoring, desarrollado por Google, usa
+				instrumentación automática que, según la versión y configuración, puede incluir
+				transformaciones en build (bytecode weaving) o instrumentación en runtime; en ambos casos
+				la instrumentación es transparente para el desarrollador. Durante el proceso, inserta
+				medición de rendimiento en los puntos de llamada a red, operaciones de base de datos y
+				trazas definidas por el desarrollador. El código fuente de la aplicación no se modifica, y
+				los resultados quedan disponibles en el panel de Firebase sin ningún código de monitoreo
+				explícito en la app.
+			</p></br>
+
         </br>
         </br>  
         
@@ -270,6 +322,15 @@ Esto es más complicado, porque presenta AspectJ Java Tools (que incluye un comp
     </li>
 	
     </UL>
+
+    <h2>Referencias (aporte 2026-1)</h2>
+    <ul>
+      <li>Google. (2023). <em>Firebase Performance Monitoring for Android</em>. https://firebase.google.com/docs/perf-mon/get-started-android</li>
+      <li>NestJS Team. (2023). <em>NestJS documentation: Interceptors</em>. https://docs.nestjs.com/interceptors</li>
+      <li>Resilience4J Team. (2023). <em>Resilience4J: Getting started with Spring Boot 3</em>. https://resilience4j.readme.io/docs/getting-started-3</li>
+      <li>Rocher, G., &amp; Radestad, J. T. (2019). <em>Micronaut in Action</em>. Manning Publications.</li>
+    </ul>
+
     <div >
         <button class="up-button" onclick="scrollToTop()">
             <img
@@ -280,6 +341,8 @@ Esto es más complicado, porque presenta AspectJ Java Tools (que incluye un comp
 	<footer class="site-footer">
 		<span class="site-footer-owner"><a href="https://github.com/ProgramacionOrientadaAspectos/POA_teoria">Programacion Orientada a Aspectos</a> is maintained by <a href="https://github.com/ProgramacionOrientadaAspectos">ProgramacionOrientadaAspectos</a>.</span>
 		<span class="site-footer-credits">This page was created by Diego Rojas, Gustavo Galvis y Dorian Tovar.</span>
+		<br>
+		<span class="site-footer-credits">This page was edited (2026-1) by Julian Esteban Cadena Rojas, Daniel Alonso Gracia Pinto, Pablo Felipe Sandoval Menjura, Juan Diego Velasquez Pinzon and Juan Camilo Vergara Tao.</span>
 	</footer>
 </section>
 

--- a/poa/poa_teoria/Pages/historia.html
+++ b/poa/poa_teoria/Pages/historia.html
@@ -181,6 +181,80 @@
         En la actualidad AspecJ, creado en 2001, ha recibido una gran acogida por la comunidad del 
         desarrollo de software, en especial en frameworks de Java como lo son Spring o Spring Boot. 
       </p>
+
+      <h2>La consolidación industrial de AOP (2003–2013)</h2>
+      <p>
+        En 2003, Xerox PARC donó el proyecto AspectJ a la Fundación Eclipse, que asumió su mantenimiento
+        bajo el nombre Eclipse AspectJ. Este cambio fue determinante: AOP dejó de ser exclusivamente un
+        proyecto de investigación académica y ganó soporte industrial y ciclos de versiones gestionados.
+        Ese mismo año, el recién nacido Spring Framework integró soporte AOP como uno de sus pilares
+        fundamentales, exponiéndolo a la industria empresarial Java por primera vez a gran escala.
+      </p>
+      <p>
+        Durante los años siguientes, la adopción de AOP enfrentó una barrera práctica: configurarlo
+        requería archivos XML extensos. La adopción de anotaciones (AspectJ 5, 2005) y su integración
+        con Spring simplificó drásticamente la configuración basada en XML, permitiendo definir aspectos
+        directamente en Java mediante anotaciones como <code>@Aspect</code>, <code>@Before</code> y
+        <code>@Around</code>. Ese mismo año, Java EE 5 estandarizó los interceptores en la especificación
+        EJB 3.0, y más tarde CDI 1.0 en 2009 los consolidó como parte central de la plataforma. Aunque el
+        vocabulario era distinto, el modelo conceptual era el mismo que el de AOP: interceptar puntos de
+        ejecución para insertar comportamiento transversal sin modificar el código base.
+      </p>
+      <p>
+        Para 2011, anotaciones como <code>@Cacheable</code>, <code>@Async</code> y
+        <code>@PreAuthorize</code> eran de uso cotidiano en millones de líneas de código en producción,
+        todas implementadas internamente como aspectos de Spring. La mayoría de los desarrolladores que
+        las usaban no las identificaban como AOP.
+      </p>
+
+      <h2>Spring Boot y la invisibilización de AOP (2014–2018)</h2>
+      <p>
+        El lanzamiento de Spring Boot 1.0 en abril de 2014 profundizó esta tendencia. Al automatizar la
+        configuración del framework, Spring Boot hizo que los aspectos se activaran solos según las
+        dependencias presentes en el proyecto. Esto democratizó el paradigma de forma masiva, aunque al
+        costo de que sus mecanismos internos se volvieran cada vez más opacos para quienes lo usaban a
+        diario.
+      </p>
+
+      <h2>GraalVM y el retorno al weaving en compilación (2018–2024)</h2>
+      <p>
+        El desafío más significativo de los años siguientes llegó con GraalVM Native Image, anunciado por
+        Oracle en 2018, que permite compilar aplicaciones Java a binarios nativos con tiempos de arranque
+        de milisegundos. El problema es que esta compilación es incompatible con el runtime weaving
+        tradicional de AOP: la generación dinámica de proxies y la reflexión sin declaración explícita son
+        técnicas que GraalVM no puede procesar estáticamente. Dos frameworks respondieron apostando por
+        trasladar el weaving al tiempo de compilación: Micronaut en 2018 y Quarkus en 2019. Ambos
+        resuelven sus aspectos durante el build mediante procesadores de anotaciones de Java, minimizando
+        o evitando la necesidad de reflexión y proxies dinámicos en ejecución para las capacidades
+        transversales principales, y logrando plena compatibilidad con GraalVM sin sacrificar las
+        capacidades transversales del paradigma.
+      </p>
+      <p>
+        Spring siguió un camino propio. Con el lanzamiento de Spring Framework 6.0 y Spring Boot 3.0 en
+        noviembre de 2022, el framework introdujo un sistema de procesamiento en tiempo de compilación
+        llamado AOT (<em>Ahead-Of-Time</em>), que analiza los aspectos durante el build y genera las
+        configuraciones necesarias para que funcionen correctamente en imágenes nativas. Por primera vez,
+        aplicaciones Spring con gestión transaccional y seguridad basadas en aspectos podían compilarse a
+        binarios nativos de forma oficial.
+      </p>
+      <p>
+        En paralelo, la proliferación de arquitecturas de microservicios trajo consigo una nueva categoría
+        de incumbencias transversales: la observabilidad distribuida. OpenTelemetry, estándar abierto
+        formado en 2019, instrumenta automáticamente aplicaciones Java mediante un agente que aplica
+        <em>load-time weaving</em> usando la biblioteca Byte Buddy. El agente intercepta, en el momento de
+        carga de clases, los puntos de entrada y salida de más de ochenta bibliotecas populares —JDBC,
+        clientes HTTP, Kafka, gRPC— e inyecta código de rastreo sin que el desarrollador modifique una
+        sola línea de su aplicación. Es uno de los ejemplos más concretos de AOP operando a escala global
+        en producción.
+      </p>
+      <p>
+        Hoy AOP es un paradigma omnipresente pero frecuentemente invisible. Según el informe
+        <em>State of Developer Ecosystem 2023</em> de JetBrains, Spring Boot es utilizado por más del 62%
+        de los desarrolladores Java a nivel mundial, lo que convierte a AOP en uno de los paradigmas con
+        mayor presencia efectiva en la industria, aunque raramente sea nombrado como tal por quienes lo
+        usan a diario.
+      </p>
+
       <br>
       <p>
         Cristina Lopes comenzó a trabajar con Kickzales y su grupo,
@@ -215,8 +289,15 @@
         ingeniería de software.
       </p>
 
+      <h2>Referencias (aporte 2026-1)</h2>
+      <ul>
+        <li>Eclipse Foundation. (2003). <em>Eclipse AspectJ project</em>. https://eclipse.org/aspectj</li>
+        <li>JetBrains. (2023). <em>State of Developer Ecosystem 2023: Java</em>. https://www.jetbrains.com/lp/devecosystem-2023/java/</li>
+        <li>OpenTelemetry. (2023). <em>Java Agent: Supported libraries and frameworks</em>. https://opentelemetry.io/docs/instrumentation/java/automatic/</li>
+        <li>Spring Team. (2022). <em>Spring Boot 3.0 release notes</em>. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes</li>
+        <li>Walls, C. (2016). <em>Spring Boot in Action</em>. Manning Publications.</li>
+      </ul>
       
-
       <p align="center">
         <img
           src="https://raw.githubusercontent.com/anfmorenoso/Archivos/master/aspc.png"
@@ -245,6 +326,8 @@
           <a href="https://github.com/jasonlong/cayman-theme">Cayman theme</a>
           by <a href="https://twitter.com/jasonlong">Jason Long</a>.</span
         >
+        <br>
+        <span class="site-footer-credits">This page was edited (2026-1) by Julian Esteban Cadena Rojas, Daniel Alonso Gracia Pinto, Pablo Felipe Sandoval Menjura, Juan Diego Velasquez Pinzon and Juan Camilo Vergara Tao.</span>
       </footer>
     </section>
     <script src="/javascripts/main.js"></script>

--- a/poa/poa_teoria/Pages/presentaciones.html
+++ b/poa/poa_teoria/Pages/presentaciones.html
@@ -125,6 +125,13 @@
     </h2>
     <iframe src="../slides/POA_2023_1.pdf" width="960px" height="600px" seamless webkitallowfullscreen
       mozallowfullscreen allowfullscreen></iframe>
+
+    <h2>
+      <a id="referencias" class="anchor" href="#referencias" aria-hidden="true"><span aria-hidden="true"
+          class="octicon octicon-link"></span></a>Presentacion 2026-1:
+    </h2>
+    <iframe src="../slides/POA_2026_1.pdf" width="960px" height="600px" seamless webkitallowfullscreen
+      mozallowfullscreen allowfullscreen></iframe>
     <div >
       <button class="up-button" onclick="scrollToTop()">
         <img
@@ -140,6 +147,8 @@
         <a href="https://github.com/ProgramacionOrientadaAspectos">ProgramacionOrientadaAspectos</a>.</span>
       <span class="site-footer-credits">This page was created by Diego Rojas, Gustavo Galvis y Dorian
         Tovar.</span>
+      <br>
+      <span class="site-footer-credits">This page was edited (2026-1) by Julian Esteban Cadena Rojas, Daniel Alonso Gracia Pinto, Pablo Felipe Sandoval Menjura, Juan Diego Velasquez Pinzon and Juan Camilo Vergara Tao.</span>
     </footer>
   </section>
 </body>

--- a/poa/poa_teoria/Pages/ventajasydesventajas.html
+++ b/poa/poa_teoria/Pages/ventajasydesventajas.html
@@ -235,6 +235,98 @@
 			</center>
 
 		</ul>
+
+		<h2>AOP en perspectiva: comparación con otros paradigmas</h2>
+		<p align="justify">
+			Entender las ventajas y desventajas de AOP de forma aislada es útil, pero resulta más claro
+			situarlo frente a los paradigmas con los que convive en la práctica.
+		</p>
+
+		<table>
+			<thead>
+				<tr>
+					<th>Dimensión</th>
+					<th>POO</th>
+					<th>Programación Funcional</th>
+					<th>AOP</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Incumbencias transversales</td>
+					<td>Débil</td>
+					<td>Moderada</td>
+					<td>Fuerte</td>
+				</tr>
+				<tr>
+					<td>Depuración</td>
+					<td>Clara</td>
+					<td>Clara</td>
+					<td>Difícil</td>
+				</tr>
+				<tr>
+					<td>Curva de aprendizaje</td>
+					<td>Baja</td>
+					<td>Alta</td>
+					<td>Media-alta</td>
+				</tr>
+				<tr>
+					<td>Madurez del ecosistema</td>
+					<td>Muy alta</td>
+					<td>Alta</td>
+					<td>Media</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<h3>AOP frente a la Programación Orientada a Objetos</h3>
+		<p align="justify">
+			POO y AOP no son paradigmas en competencia: en la práctica, AOP se implementa casi siempre
+			sobre una base orientada a objetos, añadiendo una dimensión de modularización que POO sola no
+			puede cubrir de forma limpia. El límite de POO aparece con las incumbencias transversales:
+			funcionalidades como el logging, la seguridad o las transacciones no pertenecen a ningún
+			objeto en particular, pero todos los objetos las necesitan. La solución habitual en POO —
+			duplicar ese código en cada clase, o forzar jerarquías de herencia para compartirlo —
+			genera exactamente los problemas que el paradigma intentaba resolver: acoplamiento alto,
+			código repetido y módulos que mezclan responsabilidades distintas. AOP resuelve esto de raíz
+			al permitir encapsular esas responsabilidades en un aspecto independiente que se aplica de
+			forma declarativa, sin tocar el código de las clases afectadas. La desventaja real frente a
+			POO es la transparencia: en un sistema orientado a objetos el comportamiento de un método es
+			visible en su definición, mientras que en AOP puede haber advice aplicándose sobre ese método
+			sin que ninguna línea de su código lo indique. Esto no es un defecto de diseño sino una
+			consecuencia inevitable del modelo, y es el motivo por el que AOP exige disciplina adicional
+			en documentación y en el uso de herramientas que visualicen qué aspectos afectan a qué puntos
+			del programa.
+		</p>
+
+		<h3>AOP frente a la Programación Funcional</h3>
+		<p align="justify">
+			La comparación con programación funcional es más interesante de lo que parece, porque ambos
+			paradigmas atacan el problema del código mezclado desde ángulos distintos. La programación
+			funcional lo hace apostando por funciones puras sin efectos secundarios: si cada función solo
+			depende de sus argumentos y no modifica estado externo, las incumbencias transversales tienden
+			a concentrarse en los bordes del sistema —entrada/salida, manejo de efectos— y no a
+			dispersarse por todo el código. Herramientas como las mónadas permiten componer
+			comportamientos transversales de forma explícita y tipada. La ventaja de este enfoque sobre
+			AOP es precisamente esa explicitez: el flujo de ejecución es siempre predecible y rastreable,
+			los efectos están declarados en los tipos, y depurar un sistema funcional es
+			considerablemente más sencillo que depurar uno con aspectos aplicados en runtime. Sin embargo,
+			la programación funcional no elimina las incumbencias transversales, las reubica y las hace
+			más manejables, pero en sistemas con estado complejo o con muchos efectos secundarios
+			inevitables —como la mayoría de aplicaciones empresariales— la solución funcional puede
+			volverse verbosa o requerir abstracciones avanzadas que tienen su propia curva de aprendizaje.
+			AOP en esos contextos ofrece una solución más directa aunque menos predecible en su
+			comportamiento dinámico. En la práctica, los sistemas que mejor aprovechan las fortalezas de
+			ambos enfoques suelen combinarlos: lógica de negocio modelada con principios funcionales, e
+			incumbencias transversales de infraestructura gestionadas con aspectos.
+		</p>
+
+		<h2>Referencias (aporte 2026-1)</h2>
+		<ul>
+			<li>Kiczales, G., Lamping, J., Mendhekar, A., Maeda, C., Lopes, C., Loingtier, J. M., &amp; Irwin, J. (1997). <em>Aspect-oriented programming</em>. ECOOP. Springer.</li>
+			<li>Filman, R. E., Elrad, T., Clarke, S., &amp; Akşit, M. (Eds.). (2004). <em>Aspect-Oriented Software Development</em>. Addison-Wesley.</li>
+		</ul>
+
 		<div >
 			<button class="up-button" onclick="scrollToTop()">
 			  <img
@@ -259,6 +351,8 @@
 			<br>
 			<span class="site-footer-credits">This page was modified(2023-1) by Miguel Puentes, Jhonatan Rodríguez,
 				Paula Velosa & Edgar González</span>
+			<br>
+			<span class="site-footer-credits">This page was edited (2026-1) by Julian Esteban Cadena Rojas, Daniel Alonso Gracia Pinto, Pablo Felipe Sandoval Menjura, Juan Diego Velasquez Pinzon and Juan Camilo Vergara Tao.</span>
 		</footer>
 	</section>
 	<script src="/javascripts/main.js"></script>


### PR DESCRIPTION
**Integrantes:**
- Julian Esteban Cadena Rojas — jcadenar
- Daniel Alonso Gracia Pinto — dagraciap
- Pablo Felipe Sandoval Menjura — psandoval
- Juan Diego Velasquez Pinzon — jvelasquezpi
- Juan Camilo Vergara Tao — juvergarat

**Aportes realizados a la página de Programación Orientada a Aspectos:**

- Se complementó `historia.html` con la evolución del paradigma desde 2003 hasta la actualidad.
- Se complementó `aplicaciones.html` con nuevas entradas de software que emplea AOP: Resilience4J, Micronaut, Quarkus, NestJS y Firebase Performance Monitoring.
- Se complementó `ventajasydesventajas.html` con una sección comparativa entre AOP, POO y Programación Funcional.
- Se agregó la presentación del semestre 2026-1 en `presentaciones.html`.